### PR TITLE
Removed Duplicate comments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === Quotable ===
-Contributors: josiahsprague
+Contributors: josiahsprague, alihusnainarshad
 Donate link: https://www.patreon.com/localjo
 Tags: social media, share buttons, quotes, twitter, medium
 Requires at least: 3.0.1

--- a/admin/class-quotable-admin.php
+++ b/admin/class-quotable-admin.php
@@ -2,19 +2,11 @@
 /**
  * The admin-specific functionality of the plugin.
  *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/admin
- */
-
-/**
- * The admin-specific functionality of the plugin.
- *
  * Defines the plugin name, version, and two examples hooks for how to
  * enqueue the admin-specific stylesheet and JavaScript.
  *
+ * @link       https://iamlocaljo.com
+ * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/admin
  * @author     Jo Sprague <josiah.sprague@gmail.com>

--- a/includes/class-quotable-activator.php
+++ b/includes/class-quotable-activator.php
@@ -1,19 +1,10 @@
 <?php
 /**
- * Fired during plugin activation
- *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/includes
- */
-
-/**
  * Fired during plugin activation.
  *
  * This class defines all code necessary to run during the plugin's activation.
  *
+ * @link       https://iamlocaljo.com
  * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/includes

--- a/includes/class-quotable-deactivator.php
+++ b/includes/class-quotable-deactivator.php
@@ -1,19 +1,10 @@
 <?php
 /**
- * Fired during plugin deactivation
- *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/includes
- */
-
-/**
  * Fired during plugin deactivation.
  *
  * This class defines all code necessary to run during the plugin's deactivation.
  *
+ * @link       https://iamlocaljo.com
  * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/includes

--- a/includes/class-quotable-i18n.php
+++ b/includes/class-quotable-i18n.php
@@ -1,23 +1,11 @@
 <?php
 /**
- * Define the internationalization functionality
- *
- * Loads and defines the internationalization files for this plugin
- * so that it is ready for translation.
- *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/includes
- */
-
-/**
  * Define the internationalization functionality.
  *
  * Loads and defines the internationalization files for this plugin
  * so that it is ready for translation.
  *
+ * @link       https://iamlocaljo.com
  * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/includes

--- a/includes/class-quotable-loader.php
+++ b/includes/class-quotable-loader.php
@@ -1,21 +1,13 @@
 <?php
 /**
- * Register all actions and filters for the plugin
- *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/includes
- */
-
-/**
  * Register all actions and filters for the plugin.
  *
  * Maintain a list of all hooks that are registered throughout
  * the plugin, and register them with the WordPress API. Call the
  * run function to execute the list of actions and filters.
  *
+ * @link       https://iamlocaljo.com
+ * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/includes
  * @author     Jo Sprague <josiah.sprague@gmail.com>

--- a/includes/class-quotable.php
+++ b/includes/class-quotable.php
@@ -1,18 +1,5 @@
 <?php
 /**
- * The file that defines the core plugin class
- *
- * A class definition that includes attributes and functions used across both the
- * public-facing side of the site and the admin area.
- *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/includes
- */
-
-/**
  * The core plugin class.
  *
  * This is used to define internationalization, admin-specific hooks, and
@@ -21,6 +8,7 @@
  * Also maintains the unique identifier of this plugin as well as the current
  * version of the plugin.
  *
+ * @link       https://iamlocaljo.com
  * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/includes

--- a/public/class-quotable-public.php
+++ b/public/class-quotable-public.php
@@ -2,19 +2,11 @@
 /**
  * The public-facing functionality of the plugin.
  *
- * @link       https://iamlocaljo.com
- * @since      1.0.0
- *
- * @package    Quotable
- * @subpackage Quotable/public
- */
-
-/**
- * The public-facing functionality of the plugin.
- *
  * Defines the plugin name, version, and two examples hooks for how to
  * enqueue the public-facing stylesheet and JavaScript.
- *
+ * 
+ * @link       https://iamlocaljo.com
+ * @since      1.0.0
  * @package    Quotable
  * @subpackage Quotable/public
  * @author     Jo Sprague <josiah.sprague@gmail.com>


### PR DESCRIPTION
For Example in    _quotable-wp/admin/class-quotable-admin.php_

`/**
 * The admin-specific functionality of the plugin.
 *
 * @link       https://iamlocaljo.com
 * @since      1.0.0
 *
 * @package    Quotable
 * @subpackage Quotable/admin
 */

/**
 * The admin-specific functionality of the plugin.
 *
 * Defines the plugin name, version, and two examples hooks for how to
 * enqueue the admin-specific stylesheet and JavaScript.
 *
 * @package    Quotable
 * @subpackage Quotable/admin
 * @author     Jo Sprague <josiah.sprague@gmail.com>
 */`


These 2 comment's are same, I have merged them into single comment.

/**
 * The admin-specific functionality of the plugin.
 *
 * Defines the plugin name, version, and two examples hooks for how to
 * enqueue the admin-specific stylesheet and JavaScript.
 *
 * @link       https://iamlocaljo.com
 * @since      1.0.0
 * @package    Quotable
 * @subpackage Quotable/admin
 * @author     Jo Sprague <josiah.sprague@gmail.com>
 */